### PR TITLE
Fix Aura non-HD display issue.

### DIFF
--- a/src/screenInv.c
+++ b/src/screenInv.c
@@ -320,7 +320,7 @@ static void initialize()
         return;
 	}
 	
-    fbMemory = (uint16_t*) mmap(0, finfo.smem_len, PROT_READ | PROT_WRITE, MAP_SHARED, fb0fd, 0);
+    fbMemory = (uint16_t*) mmap_orig(0, finfo.smem_len, PROT_READ | PROT_WRITE, MAP_SHARED, fb0fd, 0);
 
 	if ((int)fbMemory == -1) {
 		DEBUGPRINT("ScreenInverter: Failed to map framebuffer device to memory.\n");
@@ -363,7 +363,7 @@ static void initialize()
 	
 	if(!useHWInvert)
 	{
-		virtualFB = (uint16_t *) mmap(NULL, finfo.smem_len, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0);
+		virtualFB = (uint16_t *) mmap_orig(NULL, finfo.smem_len, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0);
 	}
 }
 


### PR DESCRIPTION
The mmap was returing 0 because it was calling the patched method
instead of the original method. This caused fbMemory to be 0 and
the writes to fbMemory to cause a segfault.

Closes issue #1, and makes the library work on Aura.
